### PR TITLE
New feature: auto-completion for the location bar

### DIFF
--- a/README
+++ b/README
@@ -10,6 +10,7 @@ Features:
 
     - A WebKit viewport
     - An input box to change the URI or to search the current page
+    - Auto-Completion for the input box based on the browsing history
     - Built-in launching of suckless' tabbed
     - Built-in adblock
     - Built-in download manager


### PR DESCRIPTION
I implemented auto-completion for the location bar.

Persistent storage of the browsing history (URI's and titles) is not implemented yet because i haven't decided on the format we should use for storing the history. There's a bookmarks file parser API in GLib but the file format has a lot of overhead (XML...). I haven't really done any serious research on that topic, though. What do you think?

Link: https://developer.gnome.org/glib/stable/glib-Bookmark-file-parser.html
