### PR TITLE
Hide progress bar once the webpage has finished loading

### DIFF
--- a/browser.c
+++ b/browser.c
@@ -322,6 +322,7 @@ changed_load_progress(GObject *obj, GParamSpec *pspec, gpointer data)
     gdouble p;
 
     p = webkit_web_view_get_estimated_load_progress(WEBKIT_WEB_VIEW(c->web_view));
+    if (p == 1) p = 0;
     gtk_entry_set_progress_fraction(GTK_ENTRY(c->location), p);
 }
 


### PR DESCRIPTION
The progressbar makes me subconsiously think a page is still loading. Pretty much all browsers I know of hide it when done loading.