### PR TITLE
Support WebKit "enable-write-console-messages-to-stdout"

### DIFF
--- a/browser.c
+++ b/browser.c
@@ -76,6 +76,7 @@ static gboolean cooperative_instances = TRUE;
 static int cooperative_pipe_fp = 0;
 static gchar *download_dir = "/var/tmp";
 static gboolean enable_webgl = FALSE;
+static gboolean enable_console_to_stdout = FALSE;
 static Window embed = 0;
 static gchar *fifo_suffix = "main";
 static gdouble global_zoom = 1.0;
@@ -203,6 +204,9 @@ client_new(const gchar *uri, WebKitWebView *related_wv, gboolean show)
     if (user_agent != NULL)
         g_object_set(G_OBJECT(webkit_web_view_get_settings(WEBKIT_WEB_VIEW(c->web_view))),
                      "user-agent", user_agent, NULL);
+
+    if (enable_console_to_stdout)
+        webkit_settings_set_enable_write_console_messages_to_stdout(webkit_web_view_get_settings(WEBKIT_WEB_VIEW(c->web_view)), TRUE);
 
     if (enable_webgl)
         webkit_settings_set_enable_webgl(webkit_web_view_get_settings(WEBKIT_WEB_VIEW(c->web_view)), TRUE);
@@ -592,6 +596,10 @@ grab_environment_configuration(void)
     e = g_getenv(__NAME_UPPERCASE__"_DOWNLOAD_DIR");
     if (e != NULL)
         download_dir = g_strdup(e);
+
+    e = g_getenv(__NAME_UPPERCASE__"_ENABLE_CONSOLE_TO_STDOUT");
+    if (e != NULL)
+        enable_console_to_stdout = TRUE;
 
     e = g_getenv(__NAME_UPPERCASE__"_ENABLE_EXPERIMENTAL_WEBGL");
     if (e != NULL)

--- a/man1/lariza.1
+++ b/man1/lariza.1
@@ -52,6 +52,9 @@ stick to XDG directories, then you should configure your
 
 This variable defaults to \fB/var/tmp\fP.
 .TP
+\fBLARIZA_ENABLE_CONSOLE_TO_STDOUT\fP
+Enable writing WebKit console messages to stdout.
+.TP
 \fBLARIZA_ENABLE_EXPERIMENTAL_WEBGL\fP
 Enable WebGL support in WebKit if this variable is set. Note that this
 is an \fBEXPERIMENTAL\fP feature. This setting could vanish from


### PR DESCRIPTION
First of all thanks for the project.
It is quite educational and provides a nice lightweight browser.
When I started using Lariza, I had problems with some web-pages.With the console log it was quite easy to find the source of the problems (e.g. settings or known WebKit issues).
I thought it might be nice to enable the output via an environment variable. Or is there already an easy way to see the WebKit console log which I missed?